### PR TITLE
[refactor] React Query 기반 로직 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,14 @@
   "packages": {
     "": {
       "name": "muuvi",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "dependencies": {
         "@react-three/drei": "^9.122.0",
         "@react-three/fiber": "^8.18.0",
         "@react-three/postprocessing": "^2.19.1",
         "@reduxjs/toolkit": "^2.2.7",
         "@supabase/supabase-js": "^2.78.0",
+        "@tanstack/react-query": "^5.90.12",
         "@types/three": "^0.181.0",
         "file-saver": "^2.0.5",
         "html-to-image": "^1.11.13",
@@ -1889,6 +1890,32 @@
         "@supabase/postgrest-js": "2.78.0",
         "@supabase/realtime-js": "2.78.0",
         "@supabase/storage-js": "2.78.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.12.tgz",
+      "integrity": "sha512-T1/8t5DhV/SisWjDnaiU2drl6ySvsHj1bHBCWNXd+/T+Hh1cf6JodyEYMd5sgwm+b/mETT4EV3H+zCVczCU5hg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.12.tgz",
+      "integrity": "sha512-graRZspg7EoEaw0a8faiUASCyJrqjKPdqJ9EwuDRUF9mEYJ1YPczI9H+/agJ0mOJkPCJDk0lsz5QTrLZ/jQ2rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@react-three/postprocessing": "^2.19.1",
     "@reduxjs/toolkit": "^2.2.7",
     "@supabase/supabase-js": "^2.78.0",
+    "@tanstack/react-query": "^5.90.12",
     "@types/three": "^0.181.0",
     "file-saver": "^2.0.5",
     "html-to-image": "^1.11.13",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { RecoilRoot } from 'recoil'
 import { lazy, Suspense } from 'react'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from './lib/react-query'
 import AuthProvider from './components/AuthProvider'
 import SimpleLoading from './components/SimpleLoading'
 
@@ -18,33 +20,35 @@ const Universe = lazy(() => import('./pages/Universe'))
 
 export default function App() {
   return (
-    <RecoilRoot>
-      <BrowserRouter>
-        <div
-          className="w-full min-h-screen flex justify-center"
-          style={{ backgroundColor: '#2e2c6a' }}
-        >
-          <div className="w-full max-w-[375px] min-h-screen relative">
-            <AuthProvider>
-              <Suspense fallback={<SimpleLoading />}>
-                <Routes>
-                  <Route path="/splash" element={<Splash />} />
-                  <Route path="/onboarding" element={<Onboarding />} />
-                  <Route path="/onboarding/step2" element={<OnboardingStep2 />} />
-                  <Route path="/main" element={<Main />} />
-                  <Route path="/content/:id" element={<Content />} />
-                  <Route path="/content/tmdb/:type/:id" element={<ContentTMDB />} />
-                  <Route path="/mypage" element={<MyPage />} />
-                  <Route path="/settings" element={<Settings />} />
-                  <Route path="/search" element={<Search />} />
-                  <Route path="/universe" element={<Universe />} />
-                  <Route path="/" element={<Splash />} />
-                </Routes>
-              </Suspense>
-            </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>
+        <BrowserRouter>
+          <div
+            className="w-full min-h-screen flex justify-center"
+            style={{ backgroundColor: '#2e2c6a' }}
+          >
+            <div className="w-full max-w-[375px] min-h-screen relative">
+              <AuthProvider>
+                <Suspense fallback={<SimpleLoading />}>
+                  <Routes>
+                    <Route path="/splash" element={<Splash />} />
+                    <Route path="/onboarding" element={<Onboarding />} />
+                    <Route path="/onboarding/step2" element={<OnboardingStep2 />} />
+                    <Route path="/main" element={<Main />} />
+                    <Route path="/content/:id" element={<Content />} />
+                    <Route path="/content/tmdb/:type/:id" element={<ContentTMDB />} />
+                    <Route path="/mypage" element={<MyPage />} />
+                    <Route path="/settings" element={<Settings />} />
+                    <Route path="/search" element={<Search />} />
+                    <Route path="/universe" element={<Universe />} />
+                    <Route path="/" element={<Splash />} />
+                  </Routes>
+                </Suspense>
+              </AuthProvider>
+            </div>
           </div>
-        </div>
-      </BrowserRouter>
-    </RecoilRoot>
+        </BrowserRouter>
+      </RecoilRoot>
+    </QueryClientProvider>
   )
 }

--- a/src/hooks/useContentData.ts
+++ b/src/hooks/useContentData.ts
@@ -1,0 +1,200 @@
+import { useMemo } from 'react'
+import type { TMDBDetail, TMDBMovieDetail, TMDBTVDetail, TMDBProvider, TMDBCredits } from '../types/tmdb'
+
+interface UseContentDataParams {
+  detail: TMDBDetail | null | undefined
+  credits: { cast: TMDBCredits['cast']; crew: TMDBCredits['crew'] } | null | undefined
+  ottProviders: TMDBProvider[] | undefined
+  type: 'movie' | 'tv'
+  language: 'ko' | 'en'
+  t: {
+    hour: string
+    minute: string
+  }
+}
+
+interface ProcessedCast {
+  id: number
+  name: string
+  character: string
+  profile_path: string | null
+}
+
+interface UseContentDataReturn {
+  genres: Array<{ id: number; name: string }>
+  ageRating: string | null
+  runtime: string | null
+  cast: ProcessedCast[]
+  director: string | null
+  writer: string | null
+  displayOttProviders: TMDBProvider[]
+  flatrateCount: number
+  freeCount: number
+  rentCount: number
+  buyCount: number
+}
+
+/**
+ * Content 데이터를 가공하는 커스텀 훅
+ * 런타임 계산, 연령 등급 추출, OTT 중복 제거 등의 로직을 담당합니다.
+ */
+export function useContentData({
+  detail,
+  credits,
+  ottProviders = [],
+  type,
+  language,
+  t,
+}: UseContentDataParams): UseContentDataReturn {
+  // 장르 추출
+  const genres = useMemo(() => {
+    return detail?.genres ?? []
+  }, [detail?.genres])
+
+  // 연령 등급 및 런타임 계산
+  const { ageRating, runtime } = useMemo(() => {
+    if (!detail) return { ageRating: null, runtime: null }
+
+    let rating: string | null = null
+    let runtimeValue: string | null = null
+
+    if (type === 'movie' && detail.mediaType === 'movie') {
+      const movieData = detail as TMDBMovieDetail
+      // 연령 등급
+      const rel = movieData.release_dates?.results?.find((r) => r.iso_3166_1 === 'KR')
+      rating = rel?.release_dates?.[0]?.certification || null
+      // 런타임
+      const rt = movieData.runtime
+      if (rt) {
+        const h = Math.floor(rt / 60)
+        const m = rt % 60
+        runtimeValue = h > 0 ? `${h}${t.hour} ${m}${t.minute}` : `${m}${t.minute}`
+      }
+    } else if (type === 'tv' && detail.mediaType === 'tv') {
+      const tvData = detail as TMDBTVDetail
+      // 연령 등급
+      const ratings = tvData.content_ratings?.results || []
+      const kr = ratings.find((r) => r.iso_3166_1 === 'KR')
+      rating = kr?.rating || null
+      if (!rating) {
+        const us = ratings.find((r) => r.iso_3166_1 === 'US')
+        rating = us?.rating || null
+        if (!rating) {
+          rating = ratings?.[0]?.rating || null
+        }
+      }
+      // 런타임
+      const epi = tvData.episode_run_time?.[0]
+      if (epi) {
+        const h = Math.floor(epi / 60)
+        const m = epi % 60
+        runtimeValue = h > 0 ? `${h}${t.hour} ${m}${t.minute}` : `${m}${t.minute}`
+      }
+    }
+
+    return { ageRating: rating, runtime: runtimeValue }
+  }, [detail, type, t])
+
+  // 출연진/제작진 처리
+  const { cast, director, writer } = useMemo(() => {
+    let processedCast: ProcessedCast[] = []
+    let processedDirector: string | null = null
+    let processedWriter: string | null = null
+
+    // Credits는 detail에 포함되어 있거나 별도로 가져온 credits 사용
+    const creditsData = detail?.credits || credits
+
+    if (creditsData && (creditsData.cast || creditsData.crew)) {
+      // 출연진
+      const castList = (creditsData.cast || []).slice(0, 6).map((actor) => ({
+        id: actor.id,
+        name: actor.name || '',
+        character: actor.character || actor.roles?.[0]?.character || '',
+        profile_path: actor.profile_path
+          ? `https://image.tmdb.org/t/p/w185${actor.profile_path}`
+          : null,
+      }))
+      processedCast = castList
+
+      // 제작진
+      const crew = creditsData.crew || []
+      // 감독: Director 우선, 없으면 Directing 부서 최상위, TV는 Executive Producer 보조
+      const directorCandidate =
+        crew.find((p) => p.job === 'Director') ||
+        crew.find((p) => p.department === 'Directing') ||
+        (type === 'tv' ? crew.find((p) => p.job === 'Executive Producer') : undefined)
+      processedDirector = directorCandidate?.name ?? null
+
+      // 극본: Writer, Screenplay, Story, Novel, TV는 Creator 포함
+      const writerCandidate =
+        crew.find((p) => p.job === 'Writer') ||
+        crew.find((p) => p.job === 'Screenplay') ||
+        crew.find((p) => p.job === 'Story') ||
+        crew.find((p) => p.job === 'Novel') ||
+        (type === 'tv' ? crew.find((p) => p.job === 'Creator') : undefined)
+
+      if (!writerCandidate && type === 'tv' && detail?.mediaType === 'tv') {
+        const tvData = detail as TMDBTVDetail
+        const createdBy = tvData.created_by
+        if (Array.isArray(createdBy) && createdBy.length > 0) {
+          processedWriter = createdBy.map((c) => c.name).filter(Boolean).join(', ')
+        }
+      } else {
+        processedWriter = writerCandidate?.name ?? null
+      }
+    }
+
+    return { cast: processedCast, director: processedDirector, writer: processedWriter }
+  }, [detail, credits, type])
+
+  // OTT Provider 필터링 및 중복 제거
+  const { displayOttProviders, flatrateCount, freeCount, rentCount, buyCount } = useMemo(() => {
+    const flatrate = ottProviders.filter((p) => p.type === 'flatrate').length
+    const free = ottProviders.filter((p) => p.type === 'free').length
+    const rent = ottProviders.filter((p) => p.type === 'rent').length
+    const buy = ottProviders.filter((p) => p.type === 'buy').length
+
+    // 필터 미선택 시 동일 플랫폼(예: wavve)이 여러 타입으로 중복 노출되는 문제 방지
+    const priority: Record<'flatrate' | 'free' | 'rent' | 'buy', number> = {
+      flatrate: 0,
+      free: 1,
+      rent: 2,
+      buy: 3,
+    }
+    const map = new Map<number, TMDBProvider>()
+    for (const p of ottProviders) {
+      const existing = map.get(p.provider_id)
+      if (!existing) {
+        map.set(p.provider_id, p)
+      } else {
+        // 더 높은 우선순위 타입을 유지
+        if (priority[p.type] < priority[existing.type]) {
+          map.set(p.provider_id, p)
+        }
+      }
+    }
+    const dedupedProviders = Array.from(map.values())
+
+    return {
+      displayOttProviders: dedupedProviders,
+      flatrateCount: flatrate,
+      freeCount: free,
+      rentCount: rent,
+      buyCount: buy,
+    }
+  }, [ottProviders])
+
+  return {
+    genres,
+    ageRating,
+    runtime,
+    cast,
+    director,
+    writer,
+    displayOttProviders,
+    flatrateCount,
+    freeCount,
+    rentCount,
+    buyCount,
+  }
+}

--- a/src/hooks/useContentData.ts
+++ b/src/hooks/useContentData.ts
@@ -6,7 +6,6 @@ interface UseContentDataParams {
   credits: { cast: TMDBCredits['cast']; crew: TMDBCredits['crew'] } | null | undefined
   ottProviders: TMDBProvider[] | undefined
   type: 'movie' | 'tv'
-  language: 'ko' | 'en'
   t: {
     hour: string
     minute: string
@@ -43,7 +42,6 @@ export function useContentData({
   credits,
   ottProviders = [],
   type,
-  language,
   t,
 }: UseContentDataParams): UseContentDataReturn {
   // 장르 추출

--- a/src/hooks/useTMDB.ts
+++ b/src/hooks/useTMDB.ts
@@ -1,0 +1,173 @@
+import { useQuery } from '@tanstack/react-query'
+import { getTMDBDetail } from '../lib/tmdb/search'
+import type { TMDBDetail, TMDBCredits, TMDBProvider, TMDMMediaItem } from '../types/tmdb'
+
+const TMDB_BASE = 'https://api.themoviedb.org/3'
+const IMG_BASE = 'https://image.tmdb.org/t/p'
+
+/**
+ * TMDB 상세 정보를 가져오는 React Query 훅
+ */
+export const useTMDBDetail = (type: 'movie' | 'tv', id: string, language: 'ko' | 'en') => {
+  return useQuery<TMDBDetail | null>({
+    queryKey: ['tmdb', 'detail', type, id, language],
+    queryFn: () => getTMDBDetail(type, id, language),
+    enabled: !!id && !!type,
+  })
+}
+
+/**
+ * TMDB Credits를 가져오는 React Query 훅
+ */
+export const useTMDBCredits = (type: 'movie' | 'tv', id: string) => {
+  return useQuery<{ cast: TMDBCredits['cast']; crew: TMDBCredits['crew'] } | null>({
+    queryKey: ['tmdb', 'credits', type, id],
+    queryFn: async () => {
+      const apiKey = import.meta.env.VITE_TMDB_API_KEY
+      if (!apiKey) return null
+      const endpoint = type === 'movie' ? 'movie' : 'tv'
+      const url = new URL(`${TMDB_BASE}/${endpoint}/${id}/credits`)
+
+      if (!apiKey.startsWith('eyJ')) {
+        url.searchParams.set('api_key', apiKey)
+      }
+
+      const res = await fetch(url.toString(), {
+        headers: apiKey.startsWith('eyJ') ? { Authorization: `Bearer ${apiKey}` } : undefined,
+      }).catch(() => null)
+
+      if (!res || !res.ok) return null
+      const json = (await res.json()) as { cast?: TMDBCredits['cast']; crew?: TMDBCredits['crew'] }
+      return {
+        cast: json.cast || [],
+        crew: json.crew || [],
+      }
+    },
+    enabled: !!id && !!type,
+  })
+}
+
+/**
+ * TMDB OTT Providers를 가져오는 React Query 훅
+ */
+export const useTMDBProviders = (type: 'movie' | 'tv', id: string) => {
+  return useQuery<TMDBProvider[]>({
+    queryKey: ['tmdb', 'providers', type, id],
+    queryFn: async () => {
+      const apiKey = import.meta.env.VITE_TMDB_API_KEY
+      if (!apiKey) return []
+      const endpoint = type === 'movie' ? 'movie' : 'tv'
+      const url = new URL(`${TMDB_BASE}/${endpoint}/${id}/watch/providers`)
+
+      if (!apiKey.startsWith('eyJ')) {
+        url.searchParams.set('api_key', apiKey)
+      }
+
+      const res = await fetch(url.toString(), {
+        headers: apiKey.startsWith('eyJ') ? { Authorization: `Bearer ${apiKey}` } : undefined,
+      }).catch(() => null)
+
+      if (!res || !res.ok) return []
+      const json = await res.json()
+      // KR가 비어있을 때를 대비해 US, JP 순으로 fallback
+      const regionOrder = ['KR', 'US', 'JP']
+      const regionKey = regionOrder.find((code) => json?.results?.[code]) as 'KR' | 'US' | 'JP' | undefined
+      const region = regionKey ? json.results[regionKey] : null
+      if (!region) return []
+
+      const list: TMDBProvider[] = []
+      ;(['flatrate', 'free', 'rent', 'buy'] as const).forEach((k) => {
+        const arr = region[k]
+        if (Array.isArray(arr)) {
+          arr.forEach((p) => {
+            if (p.provider_id && p.provider_name) {
+              list.push({
+                provider_id: p.provider_id,
+                provider_name: p.provider_name,
+                logo_path: p.logo_path ? `${IMG_BASE}/w300${p.logo_path}` : undefined,
+                type: k,
+              })
+            }
+          })
+        }
+      })
+      return list
+    },
+    enabled: !!id && !!type,
+  })
+}
+
+/**
+ * TMDB Media (비디오/이미지)를 가져오는 React Query 훅
+ */
+export const useTMDBMedia = (type: 'movie' | 'tv', id: string, language: 'ko' | 'en' = 'ko') => {
+  return useQuery<TMDMMediaItem[]>({
+    queryKey: ['tmdb', 'media', type, id, language],
+    queryFn: async () => {
+      const apiKey = import.meta.env.VITE_TMDB_API_KEY
+      if (!apiKey) return []
+      const langParam = language === 'en' ? 'en-US' : 'ko-KR'
+      const endpoint = type === 'movie' ? 'movie' : 'tv'
+      const headers = apiKey.startsWith('eyJ') ? { Authorization: `Bearer ${apiKey}` } : undefined
+      const videosUrl = new URL(`${TMDB_BASE}/${endpoint}/${id}/videos`)
+      const imagesUrl = new URL(`${TMDB_BASE}/${endpoint}/${id}/images`)
+      videosUrl.searchParams.set('language', langParam)
+      if (!apiKey.startsWith('eyJ')) {
+        videosUrl.searchParams.set('api_key', apiKey)
+        imagesUrl.searchParams.set('api_key', apiKey)
+      }
+
+      const [videosRes, imagesRes] = await Promise.all([
+        fetch(videosUrl.toString(), { headers }).catch(() => null),
+        fetch(imagesUrl.toString(), { headers }).catch(() => null),
+      ])
+
+      const items: TMDMMediaItem[] = []
+      if (videosRes && videosRes.ok) {
+        const vd = (await videosRes.json()) as {
+          results?: Array<{ type?: string; key?: string }>
+        }
+        const vids = (vd.results || [])
+          .filter((v) => v.type === 'Trailer' || v.type === 'Teaser' || v.type === 'Clip')
+          .slice(0, 3)
+        vids.forEach((v) => {
+          if (v.key) {
+            items.push({
+              type: 'video',
+              url: `https://www.youtube.com/watch?v=${v.key}`,
+              thumbnail: `https://img.youtube.com/vi/${v.key}/hqdefault.jpg`,
+            })
+          }
+        })
+      }
+      if (imagesRes && imagesRes.ok) {
+        const im = (await imagesRes.json()) as {
+          backdrops?: Array<{ file_path?: string }>
+          posters?: Array<{ file_path?: string }>
+        }
+        const backdrops = (im.backdrops || []).slice(0, 4)
+        backdrops.forEach((b) => {
+          if (b.file_path) {
+            items.push({
+              type: 'image',
+              url: `${IMG_BASE}/original${b.file_path}`,
+              thumbnail: `${IMG_BASE}/w500${b.file_path}`,
+            })
+          }
+        })
+        const posters = (im.posters || []).slice(0, 2)
+        posters.forEach((p) => {
+          if (p.file_path) {
+            items.push({
+              type: 'image',
+              url: `${IMG_BASE}/original${p.file_path}`,
+              thumbnail: `${IMG_BASE}/w500${p.file_path}`,
+            })
+          }
+        })
+      }
+      return items.slice(0, 9)
+    },
+    enabled: !!id && !!type,
+  })
+}

--- a/src/lib/react-query.ts
+++ b/src/lib/react-query.ts
@@ -1,0 +1,31 @@
+import { QueryClient } from '@tanstack/react-query'
+
+/**
+ * React Query QueryClient 설정
+ * 캐싱, 리패칭, 에러 처리 등의 전역 설정을 관리합니다.
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // 기본 캐시 시간: 5분
+      staleTime: 5 * 60 * 1000,
+      // 캐시 유지 시간: 10분
+      gcTime: 10 * 60 * 1000, // 이전 버전에서는 cacheTime이었지만 v5에서는 gcTime
+      // 자동 리패칭 비활성화 (필요시 개별 쿼리에서 활성화)
+      refetchOnWindowFocus: false,
+      // 네트워크 재연결 시 자동 리패칭 비활성화
+      refetchOnReconnect: false,
+      // 마운트 시 자동 리패칭 비활성화 (캐시된 데이터 우선 사용)
+      refetchOnMount: false,
+      // 에러 재시도 횟수
+      retry: 1,
+      // 에러 재시도 지연 시간
+      retryDelay: 1000,
+    },
+    mutations: {
+      // Mutation 에러 재시도 비활성화
+      retry: false,
+    },
+  },
+})
+

--- a/src/pages/ContentTMDB/index.tsx
+++ b/src/pages/ContentTMDB/index.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useRecoilValue } from 'recoil'
 import BottomNavigation from '../../components/BottomNavigation'
 import { languageState } from '../../recoil/userState'
-import { buildPosterUrl, getTMDBDetail, type TMDBDetail } from '../../lib/tmdb/search'
-import type { TMDBMovieDetail, TMDBTVDetail, TMDBCredits } from '../../types/tmdb'
+import { buildPosterUrl } from '../../lib/tmdb/search'
+import { useTMDBDetail, useTMDBCredits, useTMDBProviders, useTMDBMedia } from '../../hooks/useTMDB'
+import { useContentData } from '../../hooks/useContentData'
 
 // UI 텍스트 번역
 const CONTENT_TMDB_TEXT = {
@@ -79,210 +80,65 @@ export default function ContentTMDB() {
   const language = useRecoilValue(languageState)
   const t = CONTENT_TMDB_TEXT[language]
   const { type, id } = useParams<{ type: 'movie' | 'tv'; id: string }>()
-  const [detail, setDetail] = useState<TMDBDetail | null>(null)
-  // no explicit loading UI; we still fetch but render progressively
+
+  // React Query 훅들을 사용하여 데이터 가져오기
+  const { data: detail } = useTMDBDetail(type || 'movie', id || '', language)
+  const { data: credits } = useTMDBCredits(type || 'movie', id || '')
+  const { data: ottProviders = [] } = useTMDBProviders(type || 'movie', id || '')
+  const { data: mediaItems = [] } = useTMDBMedia(type || 'movie', id || '', language)
+
+  // 비즈니스 로직 분리된 커스텀 훅 사용
+  const {
+    genres,
+    ageRating,
+    runtime,
+    cast,
+    director,
+    writer,
+    displayOttProviders: baseDisplayOttProviders,
+    flatrateCount,
+    freeCount,
+    rentCount,
+    buyCount,
+  } = useContentData({
+    detail: detail || undefined,
+    credits: credits || undefined,
+    ottProviders,
+    type: type || 'movie',
+    language,
+    t: { hour: t.hour, minute: t.minute },
+  })
+
   const [isBackgroundDark, setIsBackgroundDark] = useState(true)
-  const [ageRating, setAgeRating] = useState<string | null>(null)
-  const [runtime, setRuntime] = useState<string | null>(null)
-  const [genres, setGenres] = useState<Array<{ id: number; name: string }>>([])
-  const [cast, setCast] = useState<Array<{ id: number; name: string; character: string; profile_path: string | null }>>([])
-  const [director, setDirector] = useState<string | null>(null)
-  const [writer, setWriter] = useState<string | null>(null)
-  const [mediaItems, setMediaItems] = useState<Array<{ type: 'video' | 'image'; url: string; thumbnail: string }>>([])
-  const [ottProviders, setOttProviders] = useState<
-    Array<{ provider_id: number; provider_name: string; logo_path?: string; type: 'flatrate' | 'free' | 'rent' | 'buy' }>
-  >([])
   const [selectedFilter, setSelectedFilter] = useState<'flatrate' | 'free' | 'rent' | 'buy' | null>(null)
 
-  useEffect(() => {
-    let mounted = true
-    ;(async () => {
-      if (!type || !id) return
-      try {
-        const data = await getTMDBDetail(type, id, language)
-        if (mounted) {
-          if (!data) {
-            // TMDB에서 데이터를 찾을 수 없는 경우
-            console.error('TMDB 상세 정보를 찾을 수 없습니다:', { type, id })
-            return
-          }
-          setDetail(data)
-          // 기본 정보
-          const g = data.genres ?? []
-          setGenres(g)
+  // 필터링된 OTT Providers
+  const filteredOttProviders = useMemo(() => {
+    if (!selectedFilter) return baseDisplayOttProviders
+    return baseDisplayOttProviders.filter((p) => p.type === selectedFilter)
+  }, [selectedFilter, baseDisplayOttProviders])
 
-          // 연령등급
-          if (type === 'movie' && data.mediaType === 'movie') {
-            const movieData = data as TMDBMovieDetail
-            const rel = movieData.release_dates?.results?.find((r) => r.iso_3166_1 === 'KR')
-            const cert = rel?.release_dates?.[0]?.certification || null
-            setAgeRating(cert || null)
-            const rt = movieData.runtime
-            if (rt) {
-              const h = Math.floor(rt / 60)
-              const m = rt % 60
-              setRuntime(h > 0 ? `${h}${t.hour} ${m}${t.minute}` : `${m}${t.minute}`)
-            } else {
-              setRuntime(null)
-            }
-          } else if (type === 'tv' && data.mediaType === 'tv') {
-            const tvData = data as TMDBTVDetail
-            const ratings = tvData.content_ratings?.results || []
-            const kr = ratings.find((r) => r.iso_3166_1 === 'KR')
-            let rating = kr?.rating || null
-            if (!rating) {
-              const us = ratings.find((r) => r.iso_3166_1 === 'US')
-              rating = us?.rating || null
-              if (!rating) {
-                rating = ratings?.[0]?.rating || null
-              }
-            }
-            setAgeRating(rating)
-            const epi = tvData.episode_run_time?.[0]
-            if (epi) {
-              const h = Math.floor(epi / 60)
-              const m = epi % 60
-              setRuntime(h > 0 ? `${h}${t.hour} ${m}${t.minute}` : `${m}${t.minute}`)
-            } else {
-              setRuntime(null)
-            }
-          }
+  const displayOttProviders = filteredOttProviders
 
-          // 출연/제작
-          const credits = data.credits
-          if (credits && (credits.cast || credits.crew)) {
-            const castList = (credits.cast || []).slice(0, 6).map((actor) => ({
-              id: actor.id,
-              name: actor.name || '',
-              character: actor.character || actor.roles?.[0]?.character || '',
-              profile_path: actor.profile_path
-                ? `https://image.tmdb.org/t/p/w185${actor.profile_path}`
-                : null,
-            }))
-            setCast(castList)
-            const crew = credits.crew || []
-            // 감독: Director 우선, 없으면 Directing 부서 최상위, TV는 Executive Producer 보조
-            const directorCandidate =
-              crew.find((p) => p.job === 'Director') ||
-              crew.find((p) => p.department === 'Directing') ||
-              (type === 'tv' ? crew.find((p) => p.job === 'Executive Producer') : undefined)
-            setDirector(directorCandidate?.name ?? null)
-            // 극본: Writer, Screenplay, Story, Novel, TV는 Creator 포함
-            const writerCandidate =
-              crew.find((p) => p.job === 'Writer') ||
-              crew.find((p) => p.job === 'Screenplay') ||
-              crew.find((p) => p.job === 'Story') ||
-              crew.find((p) => p.job === 'Novel') ||
-              (type === 'tv' ? crew.find((p) => p.job === 'Creator') : undefined)
-            if (!writerCandidate && type === 'tv' && data.mediaType === 'tv') {
-              const tvData = data as TMDBTVDetail
-              const createdBy = tvData.created_by
-              if (Array.isArray(createdBy) && createdBy.length > 0) {
-                setWriter(createdBy.map((c) => c.name).filter(Boolean).join(', '))
-              } else {
-                setWriter(null)
-              }
-            } else {
-              setWriter(writerCandidate?.name ?? null)
-            }
-          } else {
-            // credits가 없거나 비어있을 경우 별도로 fetch 시도
-            fetchCredits(type, id).then((creditsData) => {
-              if (mounted && creditsData) {
-                const castList = (creditsData.cast || []).slice(0, 6).map((actor) => ({
-                  id: actor.id,
-                  name: actor.name || '',
-                  character: actor.character || actor.roles?.[0]?.character || '',
-                  profile_path: actor.profile_path
-                    ? `https://image.tmdb.org/t/p/w185${actor.profile_path}`
-                    : null,
-                }))
-                setCast(castList)
-                const crew = creditsData.crew || []
-                const directorCandidate =
-                  crew.find((p) => p.job === 'Director') ||
-                  crew.find((p) => p.department === 'Directing') ||
-                  (type === 'tv' ? crew.find((p) => p.job === 'Executive Producer') : undefined)
-                setDirector(directorCandidate?.name ?? null)
-                const writerCandidate =
-                  crew.find((p) => p.job === 'Writer') ||
-                  crew.find((p) => p.job === 'Screenplay') ||
-                  crew.find((p) => p.job === 'Story') ||
-                  crew.find((p) => p.job === 'Novel') ||
-                  (type === 'tv' ? crew.find((p) => p.job === 'Creator') : undefined)
-                if (!writerCandidate && type === 'tv') {
-                  // created_by는 별도로 가져와야 할 수도 있음
-                  setWriter(null)
-                } else {
-                  setWriter(writerCandidate?.name ?? null)
-                }
-              }
-            }).catch(() => {
-              // Credits fetch 실패 시 무시
-            })
-          }
+  const handleFilterClick = useCallback((ft: 'flatrate' | 'free' | 'rent' | 'buy') => {
+    setSelectedFilter((prev) => (prev === ft ? null : ft))
+  }, [])
 
-          // 이미지/비디오
-          fetchMedia(type, id, language).then((items) => mounted && setMediaItems(items))
-          // OTT 제공자
-          fetchOttProviders(type, id).then((providers) => mounted && setOttProviders(providers))
-        }
-      } finally {
-        // Cleanup handled by mounted flag
-      }
-    })()
-    return () => {
-      mounted = false
-    }
-  }, [type, id, language, t])
+  // 제목 및 연도 계산
+  const title = useMemo(() => {
+    return (detail && ('title' in detail ? detail.title : detail.name)) || t.detail
+  }, [detail, t.detail])
 
-  const title =
-    (detail && ('title' in detail ? detail.title : detail.name)) || t.detail
-  const year = (() => {
+  const year = useMemo(() => {
     if (!detail) return ''
     if (detail.mediaType === 'movie') {
       return detail.release_date?.slice(0, 4) || ''
     } else {
       return detail.first_air_date?.slice(0, 4) || ''
     }
-  })()
-  const poster = buildPosterUrl(detail && detail.poster_path)
-  // const backdrop = buildBackdropUrl(detail && detail.backdrop_path)
+  }, [detail])
 
-  const filteredOttProviders = selectedFilter ? ottProviders.filter((p) => p.type === selectedFilter) : ottProviders
-  const flatrateCount = ottProviders.filter((p) => p.type === 'flatrate').length
-  const freeCount = ottProviders.filter((p) => p.type === 'free').length
-  const rentCount = ottProviders.filter((p) => p.type === 'rent').length
-  const buyCount = ottProviders.filter((p) => p.type === 'buy').length
-
-  // 필터 미선택 시 동일 플랫폼(예: wavve)이 여러 타입으로 중복 노출되는 문제 방지
-  const dedupedOttProviders = (() => {
-    const priority: Record<'flatrate' | 'free' | 'rent' | 'buy', number> = {
-      flatrate: 0,
-      free: 1,
-      rent: 2,
-      buy: 3,
-    }
-    const map = new Map<number, { provider_id: number; provider_name: string; logo_path?: string; type: 'flatrate' | 'free' | 'rent' | 'buy' }>()
-    for (const p of ottProviders) {
-      const existing = map.get(p.provider_id)
-      if (!existing) {
-        map.set(p.provider_id, p)
-      } else {
-        // 더 높은 우선순위 타입을 유지
-        if (priority[p.type] < priority[existing.type]) {
-          map.set(p.provider_id, p)
-        }
-      }
-    }
-    return Array.from(map.values())
-  })()
-
-  const displayOttProviders = selectedFilter ? filteredOttProviders : dedupedOttProviders
-
-  const handleFilterClick = useCallback((ft: 'flatrate' | 'free' | 'rent' | 'buy') => {
-    setSelectedFilter((prev) => (prev === ft ? null : ft))
-  }, [])
+  const poster = useMemo(() => buildPosterUrl(detail?.poster_path), [detail?.poster_path])
 
   useEffect(() => {
     if (poster) {
@@ -747,138 +603,5 @@ export default function ContentTMDB() {
   )
 }
 
-async function fetchOttProviders(
-  type: 'movie' | 'tv',
-  id: string
-): Promise<Array<{ provider_id: number; provider_name: string; logo_path?: string; type: 'flatrate' | 'free' | 'rent' | 'buy' }>> {
-  const apiKey = import.meta.env.VITE_TMDB_API_KEY
-  if (!apiKey) return []
-  const endpoint = type === 'movie' ? 'movie' : 'tv'
-  const url = new URL(`https://api.themoviedb.org/3/${endpoint}/${id}/watch/providers`)
-  // watch/providers는 language 파라미터 무시되지만 형식을 통일
-  if (!apiKey.startsWith('eyJ')) {
-    url.searchParams.set('api_key', apiKey)
-  }
-  const res = await fetch(url.toString(), {
-    headers: apiKey.startsWith('eyJ') ? { Authorization: `Bearer ${apiKey}` } : undefined,
-  }).catch(() => null)
-  if (!res || !res.ok) return []
-  const json = await res.json()
-  // KR가 비어있을 때를 대비해 US, JP 순으로 fallback
-  const regionOrder = ['KR', 'US', 'JP']
-  const regionKey = regionOrder.find((code) => json?.results?.[code]) as 'KR' | 'US' | 'JP' | undefined
-  const region = regionKey ? json.results[regionKey] : null
-  if (!region) return []
-  const list: Array<{ provider_id: number; provider_name: string; logo_path?: string; type: 'flatrate' | 'free' | 'rent' | 'buy' }> = []
-  ;(['flatrate', 'free', 'rent', 'buy'] as const).forEach((k) => {
-    const arr = region[k]
-    if (Array.isArray(arr)) {
-      arr.forEach((p) => {
-        if (p.provider_id && p.provider_name) {
-          list.push({
-            provider_id: p.provider_id,
-            provider_name: p.provider_name,
-            logo_path: p.logo_path ? `https://image.tmdb.org/t/p/w300${p.logo_path}` : undefined,
-            type: k,
-          })
-        }
-      })
-    }
-  })
-  return list
-}
-
-async function fetchCredits(
-  type: 'movie' | 'tv',
-  id: string
-): Promise<{ cast: TMDBCredits['cast']; crew: TMDBCredits['crew'] } | null> {
-  const apiKey = import.meta.env.VITE_TMDB_API_KEY
-  if (!apiKey) return null
-  const endpoint = type === 'movie' ? 'movie' : 'tv'
-  const url = new URL(`https://api.themoviedb.org/3/${endpoint}/${id}/credits`)
-  
-  if (!apiKey.startsWith('eyJ')) {
-    url.searchParams.set('api_key', apiKey)
-  }
-  
-  const res = await fetch(url.toString(), {
-    headers: apiKey.startsWith('eyJ') ? { Authorization: `Bearer ${apiKey}` } : undefined,
-  }).catch(() => null)
-  
-  if (!res || !res.ok) return null
-  const json = (await res.json()) as { cast?: TMDBCredits['cast']; crew?: TMDBCredits['crew'] }
-  return {
-    cast: json.cast || [],
-    crew: json.crew || [],
-  }
-}
-
-async function fetchMedia(
-  type: 'movie' | 'tv',
-  id: string,
-  language: 'ko' | 'en' = 'ko'
-): Promise<Array<{ type: 'video' | 'image'; url: string; thumbnail: string }>> {
-  const apiKey = import.meta.env.VITE_TMDB_API_KEY
-  if (!apiKey) return []
-  const langParam = language === 'en' ? 'en-US' : 'ko-KR'
-  const endpoint = type === 'movie' ? 'movie' : 'tv'
-  const headers = apiKey.startsWith('eyJ') ? { Authorization: `Bearer ${apiKey}` } : undefined
-  const videosUrl = new URL(`https://api.themoviedb.org/3/${endpoint}/${id}/videos`)
-  const imagesUrl = new URL(`https://api.themoviedb.org/3/${endpoint}/${id}/images`)
-  videosUrl.searchParams.set('language', langParam)
-  if (!apiKey.startsWith('eyJ')) {
-    videosUrl.searchParams.set('api_key', apiKey)
-    imagesUrl.searchParams.set('api_key', apiKey)
-  }
-  const [videosRes, imagesRes] = await Promise.all([
-    fetch(videosUrl.toString(), { headers }).catch(() => null),
-    fetch(imagesUrl.toString(), { headers }).catch(() => null),
-  ])
-  const items: Array<{ type: 'video' | 'image'; url: string; thumbnail: string }> = []
-  if (videosRes && videosRes.ok) {
-    const vd = (await videosRes.json()) as {
-      results?: Array<{ type?: string; key?: string }>
-    }
-    const vids = (vd.results || [])
-      .filter((v) => v.type === 'Trailer' || v.type === 'Teaser' || v.type === 'Clip')
-      .slice(0, 3)
-    vids.forEach((v) => {
-      if (v.key) {
-        items.push({
-          type: 'video',
-          url: `https://www.youtube.com/watch?v=${v.key}`,
-          thumbnail: `https://img.youtube.com/vi/${v.key}/hqdefault.jpg`,
-        })
-      }
-    })
-  }
-  if (imagesRes && imagesRes.ok) {
-    const im = (await imagesRes.json()) as {
-      backdrops?: Array<{ file_path?: string }>
-      posters?: Array<{ file_path?: string }>
-    }
-    const backdrops = (im.backdrops || []).slice(0, 4)
-    backdrops.forEach((b) => {
-      if (b.file_path) {
-        items.push({
-          type: 'image',
-          url: `https://image.tmdb.org/t/p/original${b.file_path}`,
-          thumbnail: `https://image.tmdb.org/t/p/w500${b.file_path}`,
-        })
-      }
-    })
-    const posters = (im.posters || []).slice(0, 2)
-    posters.forEach((p) => {
-      if (p.file_path) {
-        items.push({
-          type: 'image',
-          url: `https://image.tmdb.org/t/p/original${p.file_path}`,
-          thumbnail: `https://image.tmdb.org/t/p/w500${p.file_path}`,
-        })
-      }
-    })
-  }
-  return items.slice(0, 9)
-}
 
 

--- a/src/pages/ContentTMDB/index.tsx
+++ b/src/pages/ContentTMDB/index.tsx
@@ -105,7 +105,6 @@ export default function ContentTMDB() {
     credits: credits || undefined,
     ottProviders,
     type: type || 'movie',
-    language,
     t: { hour: t.hour, minute: t.minute },
   })
 

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useState, useCallback, useRef } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useRecoilValue, useSetRecoilState } from 'recoil'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { onboardingDataState, languageState } from '../../recoil/userState'
 import { getProfile, saveProfile } from '../../lib/supabase/profile'
 import { getRecommendations } from '../../lib/supabase/recommendations'
 import { addNotInterested, getNotInterestedContentIds, removeNotInterested } from '../../lib/supabase/notInterested'
 import { userState } from '../../recoil/userState'
 import RecommendationLoading from '../../components/RecommendationLoading'
-import SimpleLoading from '../../components/SimpleLoading'
 import RecommendationCard from '../../components/RecommendationCard'
 import NotInterestedToast from '../../components/NotInterestedToast'
 import BottomNavigation from '../../components/BottomNavigation'
@@ -69,25 +69,50 @@ const UI_TEXT = {
   },
 }
 
+// 이미지 프리로드 함수
+const preloadImages = (contents: Content[]) => {
+  contents.forEach((content) => {
+    if (content.poster_url) {
+      const img = new Image()
+      img.src = content.poster_url
+    }
+    if (content.ott_providers) {
+      content.ott_providers.forEach((provider) => {
+        if (provider.logo_path) {
+          const img = new Image()
+          img.src = provider.logo_path
+        }
+      })
+    }
+  })
+}
+
 export default function Main() {
   const navigate = useNavigate()
   const location = useLocation()
+  const queryClient = useQueryClient()
   const setOnboardingData = useSetRecoilState(onboardingDataState)
   const user = useRecoilValue(userState)
-
-  // [추가] 언어 상태 가져오기
+  const onboardingData = useRecoilValue(onboardingDataState)
   const language = useRecoilValue(languageState)
   const t = UI_TEXT[language]
   const moodMap = MOOD_TABLE[language]
 
-  const [recommendations, setRecommendations] = useState<Content[]>([])
-  const [isLoading, setIsLoading] = useState(false)
-  const [showLoadingScreen, setShowLoadingScreen] = useState(false) // 온보딩에서 넘어올 때만 true
-  const [showSimpleLoading, setShowSimpleLoading] = useState(false) // 마이페이지에서 넘어올 때 사용
-  const [profile, setProfile] = useState<Profile | null>(null)
-  const [isDataReady, setIsDataReady] = useState(false) // 데이터가 준비되어 렌더링 대기 중인지
-  
-  // 추천 데이터를 sessionStorage에 저장하는 함수
+  const userId = user?.id || 'temp-user-id'
+  const prevPathRef = useRef<string | null>(null)
+  const touchHandledRef = useRef(false)
+
+  // UI 상태
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [showNotInterestedToast, setShowNotInterestedToast] = useState(false)
+  const [toastMessage, setToastMessage] = useState<'notInterested' | 'restored'>('notInterested')
+  const [showShareToast, setShowShareToast] = useState(false)
+  const [shareToastMessage, setShareToastMessage] = useState<'imageSaved' | 'shareFailed'>('imageSaved')
+  const [touchStart, setTouchStart] = useState<number | null>(null)
+  const [touchEnd, setTouchEnd] = useState<number | null>(null)
+  const [forceRefresh, setForceRefresh] = useState(false)
+
+  // sessionStorage 헬퍼 함수들
   const saveRecommendationsToStorage = (contents: Content[]) => {
     try {
       sessionStorage.setItem('mainRecommendations', JSON.stringify(contents))
@@ -95,8 +120,7 @@ export default function Main() {
       console.error('추천 데이터 저장 실패:', error)
     }
   }
-  
-  // 프로필 데이터를 sessionStorage에 저장하는 함수
+
   const saveProfileToStorage = (profileData: Profile | null) => {
     try {
       if (profileData) {
@@ -108,8 +132,7 @@ export default function Main() {
       console.error('프로필 데이터 저장 실패:', error)
     }
   }
-  
-  // 프로필 데이터를 sessionStorage에서 복원하는 함수
+
   const loadProfileFromStorage = (): Profile | null => {
     try {
       const storedProfile = sessionStorage.getItem('mainProfile')
@@ -121,318 +144,249 @@ export default function Main() {
     }
     return null
   }
-  const onboardingData = useRecoilValue(onboardingDataState)
-  // 현재 표시 중인 카드의 인덱스 상태
-  const [currentIndex, setCurrentIndex] = useState(0)
-  // 이전 경로를 추적하기 위한 ref
-  const prevPathRef = useRef<string | null>(null)
-  // 관심없음 토스트 표시 상태
-  const [showNotInterestedToast, setShowNotInterestedToast] = useState(false)
-  // 토스트 메시지 타입 ('notInterested': 관심없음, 'restored': 관심없음 취소)
-  const [toastMessage, setToastMessage] = useState<'notInterested' | 'restored'>('notInterested')
-  // 공유 토스트 표시 상태
-  const [showShareToast, setShowShareToast] = useState(false)
-  // 공유 토스트 메시지 타입 ('imageSaved': 이미지 저장 성공, 'shareFailed': 공유 실패)
-  const [shareToastMessage, setShareToastMessage] = useState<'imageSaved' | 'shareFailed'>('imageSaved')
-  // 관심없음으로 표시된 콘텐츠 ID 목록
-  const [notInterestedIds, setNotInterestedIds] = useState<Set<string>>(new Set())
-  // 스와이프 제스처를 위한 터치 상태
-  const [touchStart, setTouchStart] = useState<number | null>(null)
-  const [touchEnd, setTouchEnd] = useState<number | null>(null)
-  // 터치 이벤트가 처리되었는지 추적 (클릭 이벤트와 중복 방지)
-  const touchHandledRef = useRef(false)
 
-  // 온보딩으로 이동하는 함수
-  const handleRestart = () => {
-    setRecommendations([])
-    saveRecommendationsToStorage([]) // sessionStorage도 초기화
-    sessionStorage.removeItem('mainRecommendations') // [추가] 명시적 초기화
-    setProfile(null)
-    setOnboardingData(null)
-    setIsLoading(false)
-    navigate('/onboarding')
-  }
-
-  // [추가] 이미지 프리로드 함수
-  const preloadImages = (contents: Content[]) => {
-    contents.forEach((content) => {
-      if (content.poster_url) {
-        const img = new Image()
-        img.src = content.poster_url
+  // 프로필 저장 Mutation
+  const saveProfileMutation = useMutation({
+    mutationFn: ({ userId, data }: { userId: string; data: typeof onboardingData }) => {
+      if (!data) throw new Error('온보딩 데이터가 없습니다.')
+      return saveProfile(userId, data)
+    },
+    onSuccess: (profile) => {
+      if (profile) {
+        // 프로필 쿼리 캐시 무효화하여 다시 가져오기
+        queryClient.invalidateQueries({ queryKey: ['profile', userId] })
+        saveProfileToStorage(profile)
+        setOnboardingData(null)
       }
-      // OTT 로고 이미지도 프리로드
-      if (content.ott_providers) {
-        content.ott_providers.forEach((provider) => {
-          if (provider.logo_path) {
-            const img = new Image()
-            img.src = provider.logo_path
-          }
-        })
+    },
+  })
+
+  // 프로필 가져오기 Query
+  const {
+    data: profile,
+    isLoading: isProfileLoading,
+    isError: isProfileError,
+  } = useQuery({
+    queryKey: ['profile', userId],
+    queryFn: async () => {
+      let profile = await getProfile(userId)
+
+      // 로그인한 사용자이고 온보딩 데이터가 없으면 최신 프로필 가져오기
+      if (user && profile && !onboardingData) {
+        const latestProfile = await getProfile(user.id)
+        if (latestProfile) {
+          profile = latestProfile
+        }
       }
-    })
-  }
 
-  const loadRecommendations = useCallback(async (forceRefresh: boolean = false) => {
-      const startTime = Date.now()
-      const MIN_LOADING_TIME = 1500 // 최소 로딩 시간 1.5초
-      
-      try {
-        // 실제 user_id 사용 (로그인한 사용자는 user.id, 비로그인은 temp-user-id)
-        const userId = user?.id || 'temp-user-id'
-
-        // 프로필 가져오기 또는 생성
-        let profile = await getProfile(userId)
-
-        if (onboardingData) {
-          const updatedProfile = await saveProfile(userId, onboardingData)
-          profile = updatedProfile ?? profile
-          // 온보딩 데이터 사용 후 클리어 (한 번만 사용되도록)
-          setOnboardingData(null)
-        }
-
-        if (user && profile && !onboardingData) {
-          const latestProfile = await getProfile(user.id)
-          if (latestProfile) {
-            profile = latestProfile // subscribed_otts 등 최신 정보 반영
-          }
-        }
-
-        if (profile) {
-          // 프로필 저장
-          setProfile(profile)
-          // 세션 스토리지에도 프로필 저장 (네비게이션 바 이동 시 복원용)
-          saveProfileToStorage(profile)
-          
-          const [notInterestedIdsFromDb, contents] = await Promise.all([
-            // 관심없음 콘텐츠 ID 목록 가져오기 (로그인한 사용자인 경우)
-            user ? getNotInterestedContentIds(user.id).catch(() => [] as string[]) : Promise.resolve([] as string[]),
-            getRecommendations(profile, forceRefresh)
-          ])
-          
-          if (user && notInterestedIdsFromDb.length > 0) {
-            setNotInterestedIds(new Set(notInterestedIdsFromDb))
-          }
-          
-          const filteredContents = contents.filter((content) => !notInterestedIdsFromDb.includes(content.id))
-          
-          const finalContents = filteredContents.slice(0, 3)
-          
-          preloadImages(finalContents)
-          
-          const elapsedTime = Date.now() - startTime
-          const remainingTime = Math.max(0, MIN_LOADING_TIME - elapsedTime)
-          
-          if (remainingTime > 0) {
-            await new Promise(resolve => setTimeout(resolve, remainingTime))
-          }
-          
-          setRecommendations(finalContents)
-          saveRecommendationsToStorage(finalContents)
-          setCurrentIndex(0)
-          setIsDataReady(true)
-        }
-      } catch (error) {
-        console.error('추천 콘텐츠 로드 실패:', error)
-        // 에러 발생 시에도 최소 로딩 시간 유지
-        const elapsedTime = Date.now() - startTime
-        const remainingTime = Math.max(0, MIN_LOADING_TIME - elapsedTime)
-        if (remainingTime > 0) {
-          await new Promise(resolve => setTimeout(resolve, remainingTime))
-        }
-        // 에러 발생 시 빈 배열로 설정하고 데이터 준비 완료 플래그 설정
-        setRecommendations([])
-        setIsDataReady(true)
+      if (profile) {
+        saveProfileToStorage(profile)
       }
-  }, [onboardingData, user])
 
-  // [추가] recommendations가 업데이트되고 렌더링된 후 로딩 종료
+      return profile
+    },
+    enabled: !!userId,
+    staleTime: 5 * 60 * 1000, // 5분간 캐시 유지
+    gcTime: 10 * 60 * 1000, // 10분간 메모리 유지
+  })
+
+  // 온보딩 데이터가 있으면 프로필 저장
   useEffect(() => {
-    if (isDataReady && recommendations.length > 0) {
-      // React가 상태를 업데이트하고 DOM에 렌더링할 시간을 줌
-      // requestAnimationFrame을 두 번 사용: 한 번은 React 업데이트, 한 번은 브라우저 렌더링
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          // 이미지가 로드될 시간을 조금 더 줌
-          setTimeout(() => {
-            setIsLoading(false)
-            setShowLoadingScreen(false)
-            setShowSimpleLoading(false)
-            setIsDataReady(false) // 플래그 리셋
-          }, 100)
-        })
-      })
-    } else if (isDataReady && recommendations.length === 0) {
-      // 데이터가 없어도 로딩 종료
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          setIsLoading(false)
-          setShowLoadingScreen(false)
-          setShowSimpleLoading(false)
-          setIsDataReady(false) // 플래그 리셋
-        })
-      })
+    if (onboardingData && userId) {
+      saveProfileMutation.mutate({ userId, data: onboardingData })
     }
-  }, [isDataReady, recommendations.length])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onboardingData, userId])
 
-  const handleRerecommend = () => {
-    void loadRecommendations(true)
-  }
+  // 관심없음 목록 가져오기 Query
+  const { data: notInterestedIdsFromDb = [] } = useQuery({
+    queryKey: ['notInterested', user?.id],
+    queryFn: () => getNotInterestedContentIds(user!.id),
+    enabled: !!user?.id,
+    staleTime: 2 * 60 * 1000, // 2분간 캐시 유지
+  })
 
+  const notInterestedIds = new Set(notInterestedIdsFromDb)
+
+  // 추천 데이터 가져오기 Query
+  const {
+    data: recommendationsData,
+    isLoading: isRecommendationsLoading,
+    isError: isRecommendationsError,
+    refetch: refetchRecommendations,
+  } = useQuery({
+    queryKey: ['recommendations', userId, profile?.id, forceRefresh],
+    queryFn: async () => {
+      if (!profile) return []
+
+      const contents = await getRecommendations(profile, forceRefresh)
+      const filteredContents = contents.filter((content) => !notInterestedIds.has(content.id))
+      const finalContents = filteredContents.slice(0, 3)
+
+      preloadImages(finalContents)
+      saveRecommendationsToStorage(finalContents)
+
+      return finalContents
+    },
+    enabled: !!profile && !isProfileLoading,
+    staleTime: 5 * 60 * 1000, // 5분간 캐시 유지
+    gcTime: 10 * 60 * 1000, // 10분간 메모리 유지
+  })
+
+  const recommendations = recommendationsData || []
+
+  // 관심없음 추가 Mutation
+  const addNotInterestedMutation = useMutation({
+    mutationFn: (contentId: string) => {
+      if (!user) throw new Error('로그인이 필요합니다.')
+      return addNotInterested(user.id, contentId)
+    },
+    onSuccess: () => {
+      // 관심없음 목록 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: ['notInterested', user?.id] })
+      // 추천 데이터 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: ['recommendations', userId] })
+    },
+  })
+
+  // 관심없음 제거 Mutation
+  const removeNotInterestedMutation = useMutation({
+    mutationFn: (contentId: string) => {
+      if (!user) throw new Error('로그인이 필요합니다.')
+      return removeNotInterested(user.id, contentId)
+    },
+    onSuccess: () => {
+      // 관심없음 목록 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: ['notInterested', user?.id] })
+      // 추천 데이터 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: ['recommendations', userId] })
+    },
+  })
+
+  // 로딩 상태 계산
+  const isLoading = isProfileLoading || isRecommendationsLoading
+  const isError = isProfileError || isRecommendationsError
+
+  // 경로 변경 감지 및 sessionStorage 복원 로직
   useEffect(() => {
     const currentPath = location.pathname
     const prevPath = sessionStorage.getItem('prevPath') || prevPathRef.current
-    
+
     const shouldShowLoadingScreen = onboardingData || prevPath?.includes('/onboarding')
-    if (shouldShowLoadingScreen) {
-      setShowLoadingScreen(true)
-      setIsLoading(true)
-      setShowSimpleLoading(false)
-      
-      try {
-        const storedRecommendations = sessionStorage.getItem('mainRecommendations')
-        const storedProfile = loadProfileFromStorage()
-        
-        if (storedRecommendations && storedProfile) {
-          const parsed = JSON.parse(storedRecommendations) as Content[]
-          if (parsed && parsed.length > 0) {
-            setRecommendations(parsed)
-            setProfile(storedProfile)
-            
-            // 이미지 프리로드
-            preloadImages(parsed)
-            setIsDataReady(true)
-            return
-          }
-        }
-      } catch (error) {
-        console.error('[온보딩에서 메인 이동] 미리 로드된 데이터 확인 실패:', error)
-      }
-      
-      // [추가] 미리 로드된 데이터가 없으면 즉시 데이터 로딩 시작
-      void loadRecommendations()
-    }
-    
     const navigationBarPaths = ['/main', '/mypage', '/search']
-    const isNavigationBarNavigation = 
-      prevPath && 
-      navigationBarPaths.includes(prevPath) && 
-      navigationBarPaths.includes(currentPath) && 
+    const isNavigationBarNavigation =
+      prevPath &&
+      navigationBarPaths.includes(prevPath) &&
+      navigationBarPaths.includes(currentPath) &&
       prevPath !== currentPath
-    
-    // [리팩토링] 1. 네비게이션 바 이동 감지 및 처리
-    // 온보딩에서 넘어온 경우는 네비게이션 바 이동이 아니므로 건너뜀
+
+    // 네비게이션 바 이동 시 sessionStorage에서 복원
     if (isNavigationBarNavigation && !shouldShowLoadingScreen) {
       try {
-        // 세션에서 추천 데이터 복원
         const storedRecommendations = sessionStorage.getItem('mainRecommendations')
         const storedProfile = loadProfileFromStorage()
-        
+
         if (storedRecommendations) {
           const parsed = JSON.parse(storedRecommendations) as Content[]
           if (parsed && parsed.length > 0) {
-            setRecommendations(parsed)
-            
+            // React Query 캐시에 직접 설정
+            queryClient.setQueryData(['recommendations', userId, storedProfile?.id, false], parsed)
             if (storedProfile) {
-              setProfile(prev => prev || storedProfile)
+              queryClient.setQueryData(['profile', userId], storedProfile)
             }
-            
-            setIsLoading(false)
-            setShowSimpleLoading(false)
-            setShowLoadingScreen(false)
-            prevPathRef.current = currentPath
-            sessionStorage.setItem('prevPath', currentPath)
-            return
+            setCurrentIndex(0)
           }
         }
       } catch (error) {
         console.error('[네비게이션 바 이동] 세션 데이터 복원 실패:', error)
       }
-      
-      setIsLoading(false)
-      setShowSimpleLoading(false)
-      setShowLoadingScreen(false)
-      prevPathRef.current = currentPath
-      sessionStorage.setItem('prevPath', currentPath)
-      return
     }
-    
-    // [리팩토링] 2. 온보딩 데이터 처리 (새로운 추천이 필요한 경우)
-    // [수정] 온보딩에서 넘어온 경우는 이미 위에서 처리했으므로 여기서는 건너뜀
-    if (onboardingData && !shouldShowLoadingScreen) {
-      sessionStorage.removeItem('mainRecommendations')
-      sessionStorage.removeItem('mainProfile')
-      setRecommendations([])
-    }
-    
-    if (recommendations.length > 0 && !onboardingData) {
-      if (!profile) {
-        const storedProfile = loadProfileFromStorage()
-        if (storedProfile) {
-          setProfile(storedProfile)
-        }
-      }
-      
-      setIsLoading(false)
-      setShowSimpleLoading(false)
-      setShowLoadingScreen(false)
-      prevPathRef.current = currentPath
-      sessionStorage.setItem('prevPath', currentPath)
-      return
-    }
-    
-    if (recommendations.length === 0 && !onboardingData) {
-      try {
-        const storedRecommendations = sessionStorage.getItem('mainRecommendations')
-        const storedProfile = loadProfileFromStorage()
-        
-        if (storedRecommendations) {
-          const parsed = JSON.parse(storedRecommendations) as Content[]
-          if (parsed && parsed.length > 0) {
-            setRecommendations(parsed)
-            
-            if (storedProfile) {
-              setProfile(storedProfile)
-            }
-            
-            setIsLoading(false)
-            setShowSimpleLoading(false)
-            setShowLoadingScreen(false)
-            prevPathRef.current = currentPath
-            sessionStorage.setItem('prevPath', currentPath)
-            return
-          }
-        }
-      } catch (error) {
-        console.error('[세션 데이터 복원] 실패:', error)
-      }
-    }
-    
-    // [리팩토링] 5. 로딩 화면 표시 및 데이터 로드
-    // 온보딩 데이터가 있거나 이전 경로가 온보딩 경로를 포함하면 로딩 화면 표시
-    // (이미 위에서 설정하고 데이터 로딩도 시작했으므로 여기서는 else 케이스만 처리)
-    if (!shouldShowLoadingScreen) {
-      setShowSimpleLoading(false)
-      setShowLoadingScreen(false)
-      setIsLoading(false)
-      prevPathRef.current = currentPath
-      sessionStorage.setItem('prevPath', currentPath)
-      void loadRecommendations()
-    } else {
-      prevPathRef.current = currentPath
-      sessionStorage.setItem('prevPath', currentPath)
-    }
-  }, [location.pathname, loadRecommendations, onboardingData])
 
-  // 로딩 화면 우선순위: 상세 로딩 > 간단한 로딩
-  // 온보딩에서 넘어올 때 상세 로딩 화면 표시
-  if (isLoading && showLoadingScreen) {
-    return <RecommendationLoading profile={profile} onboardingData={onboardingData} />
+    prevPathRef.current = currentPath
+    sessionStorage.setItem('prevPath', currentPath)
+  }, [location.pathname, userId, queryClient, onboardingData])
+
+  // recommendations가 업데이트되면 currentIndex 리셋
+  useEffect(() => {
+    if (recommendations.length > 0) {
+      setCurrentIndex(0)
+    }
+  }, [recommendations.length])
+
+  // 온보딩으로 이동하는 함수
+  const handleRestart = () => {
+    queryClient.removeQueries({ queryKey: ['recommendations', userId] })
+    queryClient.removeQueries({ queryKey: ['profile', userId] })
+    sessionStorage.removeItem('mainRecommendations')
+    sessionStorage.removeItem('mainProfile')
+    setOnboardingData(null)
+    setCurrentIndex(0)
+    navigate('/onboarding')
   }
 
-  // 마이페이지에서 넘어올 때 간단한 로딩 화면 표시
-  // (상세 로딩이 아닐 때만)
-  if (showSimpleLoading) {
-    return <SimpleLoading />
+  // 다시 추천하기
+  const handleRerecommend = () => {
+    setForceRefresh((prev) => !prev)
+    refetchRecommendations()
+  }
+
+  // 관심없음 핸들러
+  const handleNotInterested = async (contentId: string) => {
+    if (notInterestedIds.has(contentId)) {
+      // 관심없음 취소
+      if (user) {
+        try {
+          await removeNotInterestedMutation.mutateAsync(contentId)
+        } catch (error) {
+          console.error('관심없음 취소 실패:', error)
+        }
+      }
+      setToastMessage('restored')
+      setShowNotInterestedToast(true)
+      setTimeout(() => {
+        setShowNotInterestedToast(false)
+      }, 3000)
+      return
+    }
+
+    // 관심없음으로 표시
+    if (user) {
+      try {
+        await addNotInterestedMutation.mutateAsync(contentId)
+      } catch (error) {
+        console.error('관심없음 저장 실패:', error)
+      }
+    }
+
+    setToastMessage('notInterested')
+    setShowNotInterestedToast(true)
+    setTimeout(() => {
+      setShowNotInterestedToast(false)
+    }, 3000)
+  }
+
+  // 공유 성공 핸들러
+  const handleShareSuccess = () => {
+    setShareToastMessage('imageSaved')
+    setShowShareToast(true)
+    setTimeout(() => {
+      setShowShareToast(false)
+    }, 3000)
+  }
+
+  // 공유 실패 핸들러
+  const handleShareError = () => {
+    setShareToastMessage('shareFailed')
+    setShowShareToast(true)
+    setTimeout(() => {
+      setShowShareToast(false)
+    }, 3000)
+  }
+
+  // 로딩 화면 표시 (온보딩에서 넘어올 때)
+  const shouldShowLoadingScreen = onboardingData || location.state?.fromOnboarding
+  if (isLoading && shouldShowLoadingScreen) {
+    return <RecommendationLoading profile={profile || undefined} onboardingData={onboardingData || undefined} />
   }
 
   // 프로필이 있으면 프로필 사용, 없으면 온보딩 데이터 사용
@@ -460,10 +414,9 @@ export default function Main() {
     }
   }
 
-  // 스와이프 제스처 핸들러 (터치만)
+  // 스와이프 제스처 핸들러
   const minSwipeDistance = 50
 
-  // 터치 이벤트 (모바일)
   const onTouchStart = (e: React.TouchEvent) => {
     touchHandledRef.current = false
     setTouchEnd(null)
@@ -480,7 +433,7 @@ export default function Main() {
       setTouchEnd(null)
       return
     }
-    
+
     const distance = touchStart - touchEnd
     const isLeftSwipe = distance > minSwipeDistance
     const isRightSwipe = distance < -minSwipeDistance
@@ -492,86 +445,13 @@ export default function Main() {
       touchHandledRef.current = true
       handlePrev()
     }
-    
-    // 상태 초기화
+
     setTouchStart(null)
     setTouchEnd(null)
-    
-    // 짧은 시간 후 터치 처리 플래그 리셋 (클릭 이벤트와 중복 방지)
+
     setTimeout(() => {
       touchHandledRef.current = false
     }, 300)
-  }
-
-  // 관심없음 핸들러
-  const handleNotInterested = async (contentId: string) => {
-    // 이미 관심없음으로 표시된 경우 취소
-    if (notInterestedIds.has(contentId)) {
-      // 관심없음 취소
-      if (user) {
-        try {
-          await removeNotInterested(user.id, contentId)
-        } catch (error) {
-          console.error('관심없음 취소 실패:', error)
-        }
-      }
-      setNotInterestedIds((prev) => {
-        const newSet = new Set(prev)
-        newSet.delete(contentId)
-        return newSet
-      })
-      
-      // 토스트 표시 (관심없음 취소)
-      setToastMessage('restored')
-      setShowNotInterestedToast(true)
-      
-      // 3초 후 토스트 숨김
-      setTimeout(() => {
-        setShowNotInterestedToast(false)
-      }, 3000)
-      return
-    }
-
-    // 관심없음으로 표시
-    // 로그인한 사용자인 경우 데이터베이스에 저장
-    if (user) {
-      try {
-        await addNotInterested(user.id, contentId)
-      } catch (error) {
-        console.error('관심없음 저장 실패:', error)
-        // 에러가 발생해도 UI는 업데이트 (낙관적 업데이트)
-      }
-    }
-
-    // 관심없음 목록에 추가 (콘텐츠는 제거하지 않음)
-    setNotInterestedIds((prev) => new Set(prev).add(contentId))
-
-    // 토스트 표시 (관심없음)
-    setToastMessage('notInterested')
-    setShowNotInterestedToast(true)
-    
-    // 3초 후 토스트 숨김
-    setTimeout(() => {
-      setShowNotInterestedToast(false)
-    }, 3000)
-  }
-
-  // 공유 성공 핸들러
-  const handleShareSuccess = () => {
-    setShareToastMessage('imageSaved')
-    setShowShareToast(true)
-    setTimeout(() => {
-      setShowShareToast(false)
-    }, 3000)
-  }
-
-  // 공유 실패 핸들러
-  const handleShareError = () => {
-    setShareToastMessage('shareFailed')
-    setShowShareToast(true)
-    setTimeout(() => {
-      setShowShareToast(false)
-    }, 3000)
   }
 
   return (
@@ -580,51 +460,46 @@ export default function Main() {
       <NotInterestedToast isVisible={showNotInterestedToast} message={toastMessage} />
       {/* 공유 토스트 */}
       <NotInterestedToast isVisible={showShareToast} message={shareToastMessage} />
-      
+
       {/* 스크롤 가능한 콘텐츠 영역 */}
-      <div 
+      <div
         className="h-full overflow-y-auto overflow-x-hidden bg-white relative"
         onClick={(e) => {
           const target = e.target as HTMLElement
-          
-          // 버튼이나 다른 인터랙티브 요소 클릭은 무시
-          if (target.closest('button') || 
-              target.closest('a') ||
-              target.tagName === 'BUTTON' ||
-              target.tagName === 'A') {
+
+          if (
+            target.closest('button') ||
+            target.closest('a') ||
+            target.tagName === 'BUTTON' ||
+            target.tagName === 'A'
+          ) {
             return
           }
-          
-          // 카드 자체를 클릭한 경우는 무시 (카드의 handleCardClick에서 처리)
+
           if (target.closest('[data-card-container]')) {
             return
           }
-          
-          // Selection Info Card나 다른 요소 클릭은 무시
+
           if (target.closest('.bg-gray-50')) {
             return
           }
-          
-          // 터치 이벤트가 이미 처리된 경우 무시
+
           if (touchHandledRef.current) {
             return
           }
-          
-          // 화면의 좌우 절반을 나눠서 처리
+
           const containerRect = e.currentTarget.getBoundingClientRect()
           const clickX = e.clientX - containerRect.left
           const containerWidth = containerRect.width
           const isLeftClick = clickX < containerWidth / 2
-          
-          // 좌측 클릭: 이전 카드로 이동
+
           if (isLeftClick && currentIndex > 0) {
             e.stopPropagation()
             e.preventDefault()
             setCurrentIndex(currentIndex - 1)
             return
           }
-          
-          // 우측 클릭: 다음 카드로 이동
+
           if (!isLeftClick && currentIndex < recommendations.length - 1) {
             e.stopPropagation()
             e.preventDefault()
@@ -633,213 +508,185 @@ export default function Main() {
           }
         }}
       >
-
-      {/* Selection Info Card */}
-      {(displayGenre || moodNames) && (
-        <div className="w-80 py-4 left-1/2 -translate-x-1/2 top-[600px] absolute bg-gray-50 rounded-xl inline-flex flex-col justify-start items-center gap-4">
-          {displayGenre && (
-            <div className="w-72 inline-flex justify-between items-start">
-              {/* [수정] 장르 텍스트 변수 사용 */}
-              <div className="w-16 justify-start text-gray-600 text-sm font-medium font-pretendard tracking-tight">
-                {t.genre}
-              </div>
-              <div className="text-right justify-start text-gray-900 text-sm font-medium font-pretendard tracking-tight">
-                {displayGenre}
-              </div>
-            </div>
-          )}
-          {moodNames && (
-            <div className="w-72 inline-flex justify-between items-center">
-              {/* [수정] 무드 텍스트 변수 사용 */}
-              <div className="w-16 text-left justify-start text-gray-600 text-sm font-medium font-pretendard tracking-tight">
-                {t.mood}
-              </div>
-              <div className="text-right justify-start text-gray-900 text-sm font-medium font-pretendard tracking-tight">
-                {moodNames}
-              </div>
-            </div>
-          )}
-        </div>
-      )}
-
-
-
-      {/* Recommendation Cards -> Slider Container */}
-      {isLoading ? (
-        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center text-gray-600">
-          {/* [수정] 로딩 텍스트 */}
-        </div>
-      ) : recommendations.length === 0 ? (
-        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center text-gray-600">
-          {/* [수정] 결과 없음 텍스트 */}
-          {t.noContent}
-        </div>
-      ) : (
-        // 카루셀 컨테이너 (반원 배치)
-        <div 
-          className="absolute top-[80px] w-full h-[600px] overflow-hidden z-10"
-        >
-          {/* 카드들을 반원으로 배치 */}
-          <div className="relative w-full h-full">
-            {recommendations.map((content, index) => {
-              const distance = index - currentIndex
-              // 반원의 각도 계산 (최대 ±45도)
-              const angle = distance * 25 // 각 카드당 25도씩 회전
-              // 반원의 반지름 (픽셀)
-              const radius = 180
-              // 원형 배치를 위한 x, y 오프셋
-              const xOffset = Math.sin((angle * Math.PI) / 180) * radius
-              const yOffset = (1 - Math.cos((angle * Math.PI) / 180)) * radius * 0.3
-              
-              const handleCardClick = (e: React.MouseEvent) => {
-                // 터치 이벤트가 이미 처리된 경우 클릭 이벤트 무시 (중복 방지)
-                if (touchHandledRef.current) {
-                  e.preventDefault()
-                  e.stopPropagation()
-                  return
-                }
-                
-                // 카드 내부 버튼 클릭은 무시 (좋아요 버튼 등)
-                if ((e.target as HTMLElement).closest('button')) {
-                  return
-                }
-                
-                // 현재 활성화된 카드가 아닌 경우 무시
-                if (index !== currentIndex) {
-                  return
-                }
-                
-                // 카드의 실제 위치 계산
-                const cardElement = e.currentTarget as HTMLElement
-                const rect = cardElement.getBoundingClientRect()
-                const clickX = e.clientX - rect.left
-                const cardWidth = rect.width
-                const cardCenter = cardWidth / 2
-                const clickOffset = Math.abs(clickX - cardCenter)
-                const centerThreshold = cardWidth * 0.3 // 중앙 30% 영역
-                
-                // 중앙 부분을 클릭한 경우 상세 페이지로 이동
-                if (clickOffset < centerThreshold) {
-                  if (content.id) {
-                    navigate(`/content/${content.id}`)
-                  }
-                  e.stopPropagation()
-                  return
-                }
-                
-                // 좌우 클릭으로 카드 이동 (현재 인덱스 기준)
-                const isLeftClick = clickX < cardCenter
-                
-                if (isLeftClick && currentIndex > 0) {
-                  // 좌측 클릭: 이전 카드로 이동
-                  e.stopPropagation()
-                  setCurrentIndex(currentIndex - 1)
-                } else if (!isLeftClick && currentIndex < recommendations.length - 1) {
-                  // 우측 클릭: 다음 카드로 이동
-                  e.stopPropagation()
-                  setCurrentIndex(currentIndex + 1)
-                } else {
-                  // 경계에 있는 경우 이벤트 전파 차단
-                  e.stopPropagation()
-                }
-              }
-
-              return (
-                <div
-                  key={content.id}
-                  data-card-container
-                  className="absolute left-1/2 top-0 origin-center transition-all duration-500 ease-out"
-                  style={{
-                    transform: `translateX(calc(-50% + ${xOffset}px)) translateY(${yOffset}px) rotate(${angle}deg)`,
-                    zIndex: recommendations.length - Math.abs(distance),
-                  }}
-                  onTouchStart={onTouchStart}
-                  onTouchMove={onTouchMove}
-                  onTouchEnd={onTouchEnd}
-                  onClick={(e) => {
-                    // 카드 클릭은 이벤트 전파를 막아서 컨테이너의 클릭 이벤트가 발생하지 않도록
-                    e.stopPropagation()
-                  }}
-                >
-                  <RecommendationCard 
-                    content={content}
-                    isActive={index === currentIndex}
-                    distance={distance}
-                    onCardClick={handleCardClick}
-                    onShareSuccess={handleShareSuccess}
-                    onShareError={handleShareError}
-                  />
+        {/* Selection Info Card */}
+        {(displayGenre || moodNames) && (
+          <div className="w-80 py-4 left-1/2 -translate-x-1/2 top-[600px] absolute bg-gray-50 rounded-xl inline-flex flex-col justify-start items-center gap-4">
+            {displayGenre && (
+              <div className="w-72 inline-flex justify-between items-start">
+                <div className="w-16 justify-start text-gray-600 text-sm font-medium font-pretendard tracking-tight">
+                  {t.genre}
                 </div>
-              )
-            })}
+                <div className="text-right justify-start text-gray-900 text-sm font-medium font-pretendard tracking-tight">
+                  {displayGenre}
+                </div>
+              </div>
+            )}
+            {moodNames && (
+              <div className="w-72 inline-flex justify-between items-center">
+                <div className="w-16 text-left justify-start text-gray-600 text-sm font-medium font-pretendard tracking-tight">
+                  {t.mood}
+                </div>
+                <div className="text-right justify-start text-gray-900 text-sm font-medium font-pretendard tracking-tight">
+                  {moodNames}
+                </div>
+              </div>
+            )}
           </div>
-        </div>
-      )}
+        )}
 
-      {/* 인디케이터 도트 - 카드 아래, 버튼들 위에 배치 */}
-      {recommendations.length > 1 && (
-        <div className="absolute top-[508px] left-1/2 -translate-x-1/2 z-30 flex gap-2 pointer-events-none">
-          {recommendations.map((_, index) => (
-            <button
-              key={index}
-              onClick={() => setCurrentIndex(index)}
-              className={`pointer-events-auto transition-all ${
-                index === currentIndex 
-                  ? 'w-2 h-2 bg-[#2e2c6a] rounded-full' 
-                  : 'w-2 h-2 bg-[#2e2c6a]/40 rounded-full hover:bg-[#2e2c6a]/60'
-              }`}
-              aria-label={`Go to recommendation ${index + 1}`}
-            />
-          ))}
-        </div>
-      )}
+        {/* Recommendation Cards -> Slider Container */}
+        {isLoading ? (
+          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center text-gray-600">
+            {t.loading}
+          </div>
+        ) : isError || recommendations.length === 0 ? (
+          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center text-gray-600">
+            {t.noContent}
+          </div>
+        ) : (
+          <div className="absolute top-[80px] w-full h-[600px] overflow-hidden z-10">
+            <div className="relative w-full h-full">
+              {recommendations.map((content, index) => {
+                const distance = index - currentIndex
+                const angle = distance * 25
+                const radius = 180
+                const xOffset = Math.sin((angle * Math.PI) / 180) * radius
+                const yOffset = (1 - Math.cos((angle * Math.PI) / 180)) * radius * 0.3
 
-      {/* 다시하기, 리로드, 관심없음 버튼들 */}
-      <div className="absolute left-1/2 -translate-x-1/2 top-[540px] flex items-center justify-center gap-4 z-30">
-        {/* 다시하기 버튼 */}
-        <button
-          onClick={handleRestart}
-          className="px-4 py-2 bg-[#2e2c6a] text-white text-sm font-semibold rounded-lg hover:bg-[#3a3878] transition-colors whitespace-nowrap"
-        >
-          {/* [수정] 다시하기 텍스트 */}
-          {t.restart}
-        </button>
+                const handleCardClick = (e: React.MouseEvent) => {
+                  if (touchHandledRef.current) {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    return
+                  }
 
-        {/* Reload Button */}
-        <button
-          type="button"
-          aria-label="reload-recommendations"
-          className="size-8 flex items-center justify-center rounded-full bg-white/0"
-          onClick={handleRerecommend}
-        >
-          <img src={Reload} alt="reload" className="w-[28px] h-[28px]" />
-        </button>
+                  if ((e.target as HTMLElement).closest('button')) {
+                    return
+                  }
 
-        {/* 관심없음 버튼 */}
-        {recommendations.length > 0 && recommendations[currentIndex] && (
+                  if (index !== currentIndex) {
+                    return
+                  }
+
+                  const cardElement = e.currentTarget as HTMLElement
+                  const rect = cardElement.getBoundingClientRect()
+                  const clickX = e.clientX - rect.left
+                  const cardWidth = rect.width
+                  const cardCenter = cardWidth / 2
+                  const clickOffset = Math.abs(clickX - cardCenter)
+                  const centerThreshold = cardWidth * 0.3
+
+                  if (clickOffset < centerThreshold) {
+                    if (content.id) {
+                      navigate(`/content/${content.id}`)
+                    }
+                    e.stopPropagation()
+                    return
+                  }
+
+                  const isLeftClick = clickX < cardCenter
+
+                  if (isLeftClick && currentIndex > 0) {
+                    e.stopPropagation()
+                    setCurrentIndex(currentIndex - 1)
+                  } else if (!isLeftClick && currentIndex < recommendations.length - 1) {
+                    e.stopPropagation()
+                    setCurrentIndex(currentIndex + 1)
+                  } else {
+                    e.stopPropagation()
+                  }
+                }
+
+                return (
+                  <div
+                    key={content.id}
+                    data-card-container
+                    className="absolute left-1/2 top-0 origin-center transition-all duration-500 ease-out"
+                    style={{
+                      transform: `translateX(calc(-50% + ${xOffset}px)) translateY(${yOffset}px) rotate(${angle}deg)`,
+                      zIndex: recommendations.length - Math.abs(distance),
+                    }}
+                    onTouchStart={onTouchStart}
+                    onTouchMove={onTouchMove}
+                    onTouchEnd={onTouchEnd}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                    }}
+                  >
+                    <RecommendationCard
+                      content={content}
+                      isActive={index === currentIndex}
+                      distance={distance}
+                      onCardClick={handleCardClick}
+                      onShareSuccess={handleShareSuccess}
+                      onShareError={handleShareError}
+                    />
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* 인디케이터 도트 */}
+        {recommendations.length > 1 && (
+          <div className="absolute top-[508px] left-1/2 -translate-x-1/2 z-30 flex gap-2 pointer-events-none">
+            {recommendations.map((_, index) => (
+              <button
+                key={index}
+                onClick={() => setCurrentIndex(index)}
+                className={`pointer-events-auto transition-all ${
+                  index === currentIndex
+                    ? 'w-2 h-2 bg-[#2e2c6a] rounded-full'
+                    : 'w-2 h-2 bg-[#2e2c6a]/40 rounded-full hover:bg-[#2e2c6a]/60'
+                }`}
+                aria-label={`Go to recommendation ${index + 1}`}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* 다시하기, 리로드, 관심없음 버튼들 */}
+        <div className="absolute left-1/2 -translate-x-1/2 top-[540px] flex items-center justify-center gap-4 z-30">
+          <button
+            onClick={handleRestart}
+            className="px-4 py-2 bg-[#2e2c6a] text-white text-sm font-semibold rounded-lg hover:bg-[#3a3878] transition-colors whitespace-nowrap"
+          >
+            {t.restart}
+          </button>
+
           <button
             type="button"
-            aria-label="not-interested"
+            aria-label="reload-recommendations"
             className="size-8 flex items-center justify-center rounded-full bg-white/0"
-            onClick={() => {
-              const currentContent = recommendations[currentIndex]
-              if (currentContent?.id) {
-                handleNotInterested(currentContent.id)
-              }
-            }}
+            onClick={handleRerecommend}
           >
-            <img
-              src={notInterestedIds.has(recommendations[currentIndex]?.id || '') ? RecommendInactive : RecommendActive}
-              alt={notInterestedIds.has(recommendations[currentIndex]?.id || '') ? t.notInterestedCancel : t.notInterested}
-              className="w-[28px] h-[28px]"
-            />
+            <img src={Reload} alt="reload" className="w-[28px] h-[28px]" />
           </button>
-        )}
-      </div>
+
+          {recommendations.length > 0 && recommendations[currentIndex] && (
+            <button
+              type="button"
+              aria-label="not-interested"
+              className="size-8 flex items-center justify-center rounded-full bg-white/0"
+              onClick={() => {
+                const currentContent = recommendations[currentIndex]
+                if (currentContent?.id) {
+                  handleNotInterested(currentContent.id)
+                }
+              }}
+            >
+              <img
+                src={notInterestedIds.has(recommendations[currentIndex]?.id || '') ? RecommendInactive : RecommendActive}
+                alt={notInterestedIds.has(recommendations[currentIndex]?.id || '') ? t.notInterestedCancel : t.notInterested}
+                className="w-[28px] h-[28px]"
+              />
+            </button>
+          )}
+        </div>
       </div>
 
-      {/* [추가] 유니버스 진입 버튼 (우측 하단 플로팅) */}
-      {/* Selection Info Card가 있을 때는 더 위로 배치하여 겹침 방지 */}
+      {/* 유니버스 진입 버튼 */}
       <button
         onClick={() => navigate('/universe')}
         className={`fixed right-5 z-40 w-14 h-14 rounded-full backdrop-blur-md bg-[#2e2c6a]/90 shadow-[0_8px_32px_0_rgba(46,44,106,0.3),inset_0px_0px_4px_0px_rgba(255,255,255,0.1)] border border-white/10 flex items-center justify-center text-white hover:bg-[#3a3878]/90 hover:scale-105 transition-all active:scale-95 ${
@@ -847,7 +694,6 @@ export default function Main() {
         }`}
         aria-label="Go to Universe"
       >
-        {/* 별/우주 아이콘 */}
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
@@ -864,7 +710,7 @@ export default function Main() {
         </svg>
       </button>
 
-      {/* Absolute 하단 네비게이션 (오버레이) */}
+      {/* 하단 네비게이션 */}
       <div className="absolute bottom-0 left-0 right-0 z-30 pt-4 pb-2 pointer-events-none">
         <div className="pointer-events-auto">
           <BottomNavigation />
@@ -873,4 +719,3 @@ export default function Main() {
     </div>
   )
 }
-

--- a/src/types/tmdb.ts
+++ b/src/types/tmdb.ts
@@ -180,3 +180,18 @@ export interface TMDBContentDetails {
   description?: string
   descriptionEn?: string | null
 }
+
+// OTT Provider 타입 (정규화된 형태)
+export interface TMDBProvider {
+  provider_id: number
+  provider_name: string
+  logo_path?: string
+  type: 'flatrate' | 'free' | 'rent' | 'buy'
+}
+
+// Media Item 타입 (비디오/이미지)
+export interface TMDMMediaItem {
+  type: 'video' | 'image'
+  url: string
+  thumbnail: string
+}


### PR DESCRIPTION
## 변경 사항
- 기존 useEffect, useState로 작업되었던 코드를 React Query로 수정

## 작업 내용
- React Query 도입: useEffect/useState 기반 데이터 페칭을 useQuery/useMutation으로 전환하여 캐싱, 자동 리패칭, Race Condition 방지 적용
- Main/Content 페이지 리팩토링: 서버 상태 관리를 React Query로 분리 후 쿼리 로직 단순화로 불필요한 요청 제거
- ContentTMDB 컴포넌트의 데이터 페칭 로직도 useEffect에서 React Query로 전환하고, 비즈니스 로직을 커스텀 훅으로 분리

## 체크리스트
- [x] 코드 리뷰 완료
- [x] 테스트 완료
- [x] 문서 업데이트 (필요시)

## 관련 이슈
Closes #50 